### PR TITLE
IaC + Container scan composite actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,22 @@ Security-related composite actions used in Vermeer's CI pipeline
 
 ## Actions
 
+### container-scan
+
+Scan a container image for vulnerabilities
+
+### iac-scan
+
+Scan Infrastructure-as-Code files for configuration issues including Terraform, Kubernetes, Helm, etc.
+
 ### report-issue
 
 Add a custom issue to the code compliance tracker
 
-### secret-scan
+### secret-scan [DEPRECATED]
 
 Scan for secrets such as API keys, passwords, etc. in the code
 
-### secret-report
+### secret-report [DEPRECATED]
 
 If secret-scan fails, comment on the PR with instructions for remediation and notify the security team for auditing purposes

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -21,20 +21,21 @@ inputs:
 
 runs:
   using: "composite"
-  defaults:
-      run:
-        shell: bash
+
   steps:
     - name: Download Wiz CLI
+      shell: bash
       run: curl -o wizcli https://wizcli.app.wiz.io/latest/wizcli && chmod +x wizcli
 
     - name: Authenticate to Wiz
+      shell: bash
       run: ./wizcli auth --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET"
       env:
         WIZ_CLIENT_ID: ${{ inputs.client-id }}
         WIZ_CLIENT_SECRET: ${{ inputs.client-secret }}
 
     - name: Run Wiz CLI IaC scan
+      shell: bash
       run: |
         echo "# Wiz Container Scan" > output.txt
         ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" --output scan.txt,human,true
@@ -42,6 +43,7 @@ runs:
         cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
 
     - name: Output findings to summary
+      shell: bash
       if: ${{ failure() }}
       run: |
         echo "### ❌ Issues found!" >> output.txt
@@ -51,6 +53,7 @@ runs:
         cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
 
     - name: Comment on PR
+      shell: bash
       if: ${{ inputs.app-key != 'no-key' && failure() }}
       uses: thollander/actions-comment-pull-request@v2
       with:

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -39,7 +39,8 @@ runs:
       continue-on-error: true
       shell: bash
       run: |
-        echo "# Wiz Container Scan ${{ inputs.tag }}" > output.txt
+        echo "# Wiz Container Scan" > output.txt
+        echo "__Image:__ ${{ inputs.tag }}" >> outputs.txt
         ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" --policy-hits-only --output scan.zip,csv-zip,true
 
     - name: Output findings to summary

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -1,6 +1,10 @@
 name: Wiz Container Image Scan
 
 inputs:
+  artifacts:
+    description: Export the Wiz scan as a zipped CSV artifact
+    required: false
+    default: ""
   app-id:
     description: GitHub App ID used to comment on PR
     required: false
@@ -67,7 +71,7 @@ runs:
 
     - name: upload zip
       uses: actions/upload-artifact@v4
-      if:  ${{ steps.cli-scan.outcome != 'success' }}
+      if:  ${{ inputs.artifacts != '' && steps.cli-scan.outcome != 'success' }}
       with:
         name: wiz-artifact
         path: scan.zip

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -53,7 +53,6 @@ runs:
         cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
 
     - name: Comment on PR
-      shell: bash
       if: ${{ inputs.app-key != 'no-key' && failure() }}
       uses: thollander/actions-comment-pull-request@v2
       with:

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -35,7 +35,7 @@ runs:
         WIZ_CLIENT_SECRET: ${{ inputs.client-secret }}
 
     - name: Run Wiz CLI IaC scan
-      step: cli-scan
+      id: cli-scan
       continue-on-error: true
       shell: bash
       run: |

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -30,12 +30,13 @@ runs:
       run: |
         echo "# Wiz Container Scan" >> $GITHUB_STEP_SUMMARY
         ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" --output scan.txt,human,true
-        echo "No issues found!" >> $GITHUB_STEP_SUMMARY
+        echo "### ✅ No issues found!" >> $GITHUB_STEP_SUMMARY
 
     - name: Output findings to summary
       if: ${{ failure() }}
       shell: bash
       run: |
+        echo "### ❌ Issues found!" >> $GITHUB_STEP_SUMMARY
         cat scan.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Please update the above packages to remove the vulnerabilities." >> $GITHUB_STEP_SUMMARY

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -55,13 +55,13 @@ runs:
       if:  ${{ steps.cli-scan.outcome != 'success' }}
       run: |
         echo "### ❌ Issues found!" >> output.txt
+        echo "<details><summary>Please update the following packages in the container image:</summary>" >> output.txt
+        echo "" >> output.txt
         unzip scan.zip
         echo "|severity|vulnerability|name|description|" >> output.txt
         echo "| -- | -- | -- | -- | " >> output.txt
         tail -n +2 scan.csv | awk '{ if ($1=="HIGH" || $1=="CRITICAL") {printf "|"; printf $1; printf "|"; printf $2; printf "|"; printf $5; printf "|"; printf $9; print "|" }}' FPAT='[^,]*|("([^"]|"")*")' >> output.txt
-        # cat scan.txt >> output.txt
-        echo "" >> output.txt
-        echo "Please update the above packages to remove the vulnerabilities." >> output.txt
+        echo "</details>" >> output.txt
         cat output.txt >> $GITHUB_STEP_SUMMARY
 
     - name: upload zip

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -14,9 +14,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
     - name: Download Wiz CLI
       run: curl -o wizcli https://wizcli.app.wiz.io/latest/wizcli && chmod +x wizcli
 

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -20,7 +20,7 @@ runs:
 
     - name: Authenticate to Wiz
       shell: bash
-      run: ./wizcli auth --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET"
+      run: ./wizcli auth --id "${{ inputs.client-id }}" --secret "${{ inputs.client-secret }}"
       env:
         WIZ_CLIENT_ID: ${{ inputs.client-id }}
         WIZ_CLIENT_SECRET: ${{ inputs.client-key }}

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -24,6 +24,6 @@ runs:
         WIZ_CLIENT_SECRET: ${{ inputs.client-key }}
 
     - name: Run wiz CLI IaC scan
-      run: ./wizcli docker scan --image $TAG --policy "Vermeer Vulnerability Policy"
+      run: ./wizcli docker scan --image $TAG --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy"
       env:
         TAG: ${{ inputs.tag }}

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -21,12 +21,7 @@ runs:
     - name: Authenticate to Wiz
       shell: bash
       run: ./wizcli auth --id "${{ inputs.client-id }}" --secret "${{ inputs.client-secret }}"
-      env:
-        WIZ_CLIENT_ID: ${{ inputs.client-id }}
-        WIZ_CLIENT_SECRET: ${{ inputs.client-key }}
 
     - name: Run wiz CLI IaC scan
       shell: bash
-      run: ./wizcli docker scan --image $TAG --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy"
-      env:
-        TAG: ${{ inputs.tag }}
+      run: ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy"

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -1,0 +1,32 @@
+name: Wiz Container Image Scan
+
+inputs:
+  client-id:
+    description: Wiz service account client ID
+    required: true
+  client-secret:
+    description: Wiz service account client secret
+    required: true
+  tag:
+    description: Tag of the container image to be scanned
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Download Wiz CLI
+      run: curl -o wizcli https://wizcli.app.wiz.io/latest/wizcli && chmod +x wizcli
+
+    - name: Authenticate to Wiz
+      run: ./wizcli auth --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET"
+      env:
+        WIZ_CLIENT_ID: ${{ inputs.client-id }}
+        WIZ_CLIENT_SECRET: ${{ inputs.client-key }}
+
+    - name: Run wiz CLI IaC scan
+      run: ./wizcli docker scan --image $TAG --policy "Vermeer Vulnerability Policy"
+      env:
+        TAG: ${{ inputs.tag }}

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -1,6 +1,14 @@
 name: Wiz Container Image Scan
 
 inputs:
+  app-id:
+    description: GitHub App ID used to comment on PR
+    required: false
+    default: ""
+  app-key:
+    description: Private key for above App ID
+    required: false
+    default: "no-key"
   client-id:
     description: Wiz service account client ID
     required: true
@@ -28,14 +36,23 @@ runs:
 
     - name: Run Wiz CLI IaC scan
       run: |
-        echo "# Wiz Container Scan" >> $GITHUB_STEP_SUMMARY
+        echo "# Wiz Container Scan" > output.txt
         ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" --output scan.txt,human,true
-        echo "### ✅ No issues found!" >> $GITHUB_STEP_SUMMARY
+        echo "### ✅ No issues found!" >> output.txt
+        cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
 
     - name: Output findings to summary
       if: ${{ failure() }}
       run: |
-        echo "### ❌ Issues found!" >> $GITHUB_STEP_SUMMARY
-        cat scan.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "Please update the above packages to remove the vulnerabilities." >> $GITHUB_STEP_SUMMARY
+        echo "### ❌ Issues found!" >> output.txt
+        cat scan.txt | xargs -n1 -d'\n' echo "$*" >> output.txt
+        echo "" >> output.txt
+        echo "Please update the above packages to remove the vulnerabilities." >> output.txt
+        cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
+
+    - name: Comment on PR
+      if: ${{ inputs.app-key != 'no-key' && failure() }}
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
+        filePath: ./output.txt

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -56,9 +56,9 @@ runs:
       run: |
         echo "### ❌ Issues found!" >> output.txt
         unzip scan.zip
-        echo "|severity|vulnerability|name|" >> output.txt
-        echo "| -- | -- | -- |" >> output.txt
-        tail -n +2 scan.csv | awk '{ if ($1=="HIGH" || $1=="CRITICAL") {printf "|"; printf $1; printf "|"; printf $2; printf "|"; printf $5; print "|" }}' FPAT='[^,]*|("([^"]|"")*")' >> output.txt
+        echo "|severity|vulnerability|name|description|" >> output.txt
+        echo "| -- | -- | -- | -- | " >> output.txt
+        tail -n +2 scan.csv | awk '{ if ($1=="HIGH" || $1=="CRITICAL") {printf "|"; printf $1; printf "|"; printf $2; printf "|"; printf $5; printf "|"; printf $9; print "|" }}' FPAT='[^,]*|("([^"]|"")*")' >> output.txt
         # cat scan.txt >> output.txt
         echo "" >> output.txt
         echo "Please update the above packages to remove the vulnerabilities." >> output.txt

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -55,6 +55,10 @@ runs:
       if:  ${{ steps.cli-scan.outcome != 'success' }}
       run: |
         echo "### ❌ Issues found!" >> output.txt
+        unzip scan.zip
+        echo "|severity|vulnerability|name|" >> output.txt
+        echo "| -- | -- | -- |" >> output.txt
+        tail -n +2 scan.csv | awk '{ if ($1=="HIGH" || $1=="CRITICAL") {printf "|"; printf $1; printf "|"; printf $2; printf "|"; printf $5; print "|" }}' FPAT='[^,]*|("([^"]|"")*")' >> output.txt
         # cat scan.txt >> output.txt
         echo "" >> output.txt
         echo "Please update the above packages to remove the vulnerabilities." >> output.txt

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -35,16 +35,24 @@ runs:
         WIZ_CLIENT_SECRET: ${{ inputs.client-secret }}
 
     - name: Run Wiz CLI IaC scan
+      step: cli-scan
+      continue-on-error: true
       shell: bash
       run: |
         echo "# Wiz Container Scan" > output.txt
         ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" --output scan.txt,human,true
-        echo "### ✅ No issues found!" >> output.txt
-        cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
 
     - name: Output findings to summary
       shell: bash
-      if: ${{ failure() }}
+      if: ${{ steps.cli-scan.outcome == 'success' }}
+      run: |
+        echo "### ✅ No issues found!" >> output.txt
+        cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
+
+
+    - name: Output findings to summary
+      shell: bash
+      if:  ${{ steps.cli-scan.outcome != 'success' }}
       run: |
         echo "### ❌ Issues found!" >> output.txt
         cat scan.txt | xargs -n1 -d'\n' echo "$*" >> output.txt
@@ -53,7 +61,7 @@ runs:
         cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
 
     - name: Comment on PR
-      if: ${{ inputs.app-key != 'no-key' && failure() }}
+      if: ${{ inputs.app-key != 'no-key' &&  ${{ steps.cli-scan.outcome != 'success' }} }}
       uses: thollander/actions-comment-pull-request@v2
       with:
         GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -58,7 +58,7 @@ runs:
         cat scan.txt >> output.txt
         echo "" >> output.txt
         echo "Please update the above packages to remove the vulnerabilities." >> output.txt
-        cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
+        cat output.txt >> $GITHUB_STEP_SUMMARY
 
     - name: Comment on PR
       if: ${{ inputs.app-key != 'no-key' && steps.cli-scan.outcome != 'success' }} 

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -61,7 +61,7 @@ runs:
         cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
 
     - name: Comment on PR
-      if: ${{ inputs.app-key != 'no-key' &&  ${{ steps.cli-scan.outcome != 'success' }} }}
+      if: ${{ inputs.app-key != 'no-key' && steps.cli-scan.outcome != 'success' }} 
       uses: thollander/actions-comment-pull-request@v2
       with:
         GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -29,13 +29,13 @@ runs:
       shell: bash
       run: |
         echo "# Wiz Container Scan" >> $GITHUB_STEP_SUMMARY
-        ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" | tee scan.txt
+        ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" --output scan.txt,human,true
         echo "No issues found!" >> $GITHUB_STEP_SUMMARY
 
     - name: Output findings to summary
       if: ${{ failure() }}
       shell: bash
       run: |
-        grep 'Severity: CRITICAL\|Severity: HIGH' -B 1 -A 1 scan.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
+        cat scan.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Please update the above packages to remove the vulnerabilities." >> $GITHUB_STEP_SUMMARY

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -20,7 +20,10 @@ runs:
 
     - name: Authenticate to Wiz
       shell: bash
-      run: ./wizcli auth --id "${{ inputs.client-id }}" --secret "${{ inputs.client-secret }}"
+      run: ./wizcli auth --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET"
+      env:
+        WIZ_CLIENT_ID: ${{ inputs.client-id }}
+        WIZ_CLIENT_SECRET: ${{ inputs.client-secret }}
 
     - name: Run wiz CLI IaC scan
       shell: bash

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -25,6 +25,17 @@ runs:
         WIZ_CLIENT_ID: ${{ inputs.client-id }}
         WIZ_CLIENT_SECRET: ${{ inputs.client-secret }}
 
-    - name: Run wiz CLI IaC scan
+    - name: Run Wiz CLI IaC scan
       shell: bash
-      run: ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy"
+      run: |
+        echo "# Wiz Container Scan" >> $GITHUB_STEP_SUMMARY
+        ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" | tee scan.txt
+        echo "No issues found!" >> $GITHUB_STEP_SUMMARY
+
+    - name: Output findings to summary
+      if: ${{ failure() }}
+      shell: bash
+      run: |
+        grep 'Severity: CRITICAL\|Severity: HIGH' -B 1 -A 1 scan.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Please update the above packages to remove the vulnerabilities." >> $GITHUB_STEP_SUMMARY

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -40,7 +40,7 @@ runs:
       shell: bash
       run: |
         echo "# Wiz Container Scan ${{ inputs.tag }}" > output.txt
-        ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" -C -S -T --output scan.txt,human,true
+        ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" -C -S -T --output scan.txt,json,true
 
     - name: Output findings to summary
       shell: bash
@@ -55,7 +55,7 @@ runs:
       if:  ${{ steps.cli-scan.outcome != 'success' }}
       run: |
         echo "### ❌ Issues found!" >> output.txt
-        cat scan.txt | xargs -n1 -d'\n' echo "$*" >> output.txt
+        cat scan.txt >> output.txt
         echo "" >> output.txt
         echo "Please update the above packages to remove the vulnerabilities." >> output.txt
         cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -39,8 +39,8 @@ runs:
       continue-on-error: true
       shell: bash
       run: |
-        echo "# Wiz Container Scan" > output.txt
-        ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" --output scan.txt,human,true
+        echo "# Wiz Container Scan ${{ inputs.tag }}" > output.txt
+        ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" -C -S -T --output scan.txt,human,true
 
     - name: Output findings to summary
       shell: bash

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -40,7 +40,7 @@ runs:
       shell: bash
       run: |
         echo "# Wiz Container Scan ${{ inputs.tag }}" > output.txt
-        ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" -C -S -T --output scan.txt,json,true
+        ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" --policy-hits-only --output scan.txt,sarif,true
 
     - name: Output findings to summary
       shell: bash

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -48,7 +48,7 @@ runs:
       if: ${{ steps.cli-scan.outcome == 'success' }}
       run: |
         echo "### ✅ No issues found!" >> output.txt
-        cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
+        cat output.txt >> $GITHUB_STEP_SUMMARY
 
 
     - name: Output findings to summary

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -40,7 +40,7 @@ runs:
       shell: bash
       run: |
         echo "# Wiz Container Scan ${{ inputs.tag }}" > output.txt
-        ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" --policy-hits-only --output scan.txt,sarif,true
+        ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" --policy-hits-only --output scan.zip,csv-zip,true
 
     - name: Output findings to summary
       shell: bash
@@ -55,10 +55,17 @@ runs:
       if:  ${{ steps.cli-scan.outcome != 'success' }}
       run: |
         echo "### ❌ Issues found!" >> output.txt
-        cat scan.txt >> output.txt
+        # cat scan.txt >> output.txt
         echo "" >> output.txt
         echo "Please update the above packages to remove the vulnerabilities." >> output.txt
         cat output.txt >> $GITHUB_STEP_SUMMARY
+
+    - name: upload zip
+      uses: actions/upload-artifact@v4
+      if:  ${{ steps.cli-scan.outcome != 'success' }}
+      with:
+        name: wiz-artifact
+        path: scan.zip
 
     - name: Comment on PR
       if: ${{ inputs.app-key != 'no-key' && steps.cli-scan.outcome != 'success' }} 

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -13,20 +13,20 @@ inputs:
 
 runs:
   using: "composite"
+  defaults:
+      run:
+        shell: bash
   steps:
     - name: Download Wiz CLI
-      shell: bash
       run: curl -o wizcli https://wizcli.app.wiz.io/latest/wizcli && chmod +x wizcli
 
     - name: Authenticate to Wiz
-      shell: bash
       run: ./wizcli auth --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET"
       env:
         WIZ_CLIENT_ID: ${{ inputs.client-id }}
         WIZ_CLIENT_SECRET: ${{ inputs.client-secret }}
 
     - name: Run Wiz CLI IaC scan
-      shell: bash
       run: |
         echo "# Wiz Container Scan" >> $GITHUB_STEP_SUMMARY
         ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" --output scan.txt,human,true
@@ -34,7 +34,6 @@ runs:
 
     - name: Output findings to summary
       if: ${{ failure() }}
-      shell: bash
       run: |
         echo "### ❌ Issues found!" >> $GITHUB_STEP_SUMMARY
         cat scan.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -15,15 +15,18 @@ runs:
   using: "composite"
   steps:
     - name: Download Wiz CLI
+      shell: bash
       run: curl -o wizcli https://wizcli.app.wiz.io/latest/wizcli && chmod +x wizcli
 
     - name: Authenticate to Wiz
+      shell: bash
       run: ./wizcli auth --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET"
       env:
         WIZ_CLIENT_ID: ${{ inputs.client-id }}
         WIZ_CLIENT_SECRET: ${{ inputs.client-key }}
 
     - name: Run wiz CLI IaC scan
+      shell: bash
       run: ./wizcli docker scan --image $TAG --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy"
       env:
         TAG: ${{ inputs.tag }}

--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -40,7 +40,7 @@ runs:
       shell: bash
       run: |
         echo "# Wiz Container Scan" > output.txt
-        echo "__Image:__ ${{ inputs.tag }}" >> outputs.txt
+        echo "__Image:__ ${{ inputs.tag }}" >> output.txt
         ./wizcli docker scan --image ${{ inputs.tag }} --secrets --policy "Vermeer Vulnerability Policy,Vermeer Secrets Policy" --policy-hits-only --output scan.zip,csv-zip,true
 
     - name: Output findings to summary

--- a/iac-scan/action.yml
+++ b/iac-scan/action.yml
@@ -11,9 +11,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
     - name: Download Wiz CLI
       run: curl -o wizcli https://wizcli.app.wiz.io/latest/wizcli && chmod +x wizcli
 

--- a/iac-scan/action.yml
+++ b/iac-scan/action.yml
@@ -1,6 +1,10 @@
 name: Wiz IaC Scan
 
 inputs:
+  artifacts:
+    description: Export the Wiz scan as a zipped CSV artifact
+    required: false
+    default: ""
   app-id:
     description: GitHub App ID used to comment on PR
     required: false
@@ -62,7 +66,7 @@ runs:
 
     - name: upload zip
       uses: actions/upload-artifact@v4
-      if:  ${{ steps.cli-scan.outcome != 'success' }}
+      if:  ${{ inputs.artifacts != '' && steps.cli-scan.outcome != 'success' }}
       with:
         name: wiz-artifact
         path: scan.zip

--- a/iac-scan/action.yml
+++ b/iac-scan/action.yml
@@ -1,0 +1,27 @@
+name: Wiz IaC Scan
+
+inputs:
+  client-id:
+    description: Wiz service account client ID
+    required: true
+  client-secret:
+    description: Wiz service account client secret
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Download Wiz CLI
+      run: curl -o wizcli https://wizcli.app.wiz.io/latest/wizcli && chmod +x wizcli
+
+    - name: Authenticate to Wiz
+      run: ./wizcli auth --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET"
+      env:
+        WIZ_CLIENT_ID: ${{ inputs.client-id }}
+        WIZ_CLIENT_SECRET: ${{ inputs.client-key }}
+
+    - name: Run wiz CLI IaC scan
+      run: ./wizcli iac scan --path . --policy "Vermeer IaC Policy"

--- a/iac-scan/action.yml
+++ b/iac-scan/action.yml
@@ -10,6 +10,9 @@ inputs:
 
 runs:
   using: "composite"
+  defaults:
+      run:
+        shell: bash
   steps:
     - name: Download Wiz CLI
       run: curl -o wizcli https://wizcli.app.wiz.io/latest/wizcli && chmod +x wizcli
@@ -20,5 +23,16 @@ runs:
         WIZ_CLIENT_ID: ${{ inputs.client-id }}
         WIZ_CLIENT_SECRET: ${{ inputs.client-secret }}
 
-    - name: Run wiz CLI IaC scan
-      run: ./wizcli iac scan --path . --policy "Vermeer IaC Policy"
+    - name: Run Wiz CLI IaC scan
+      run: |
+        echo "# Wiz IaC Scan" >> $GITHUB_STEP_SUMMARY
+        ./wizcli iac scan --path . --policy "Vermeer IaC Policy" --output scan.txt,human,true
+        echo "### ✅ No issues found!" >> $GITHUB_STEP_SUMMARY
+
+    - name: Output findings to summary
+      if: ${{ failure() }}
+      run: |
+        echo "### ❌ Issues found!" >> $GITHUB_STEP_SUMMARY
+        cat scan.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Please address the above misconfigurations." >> $GITHUB_STEP_SUMMARY

--- a/iac-scan/action.yml
+++ b/iac-scan/action.yml
@@ -44,7 +44,7 @@ runs:
       if: ${{ steps.cli-scan.outcome == 'success' }}
       run: |
         echo "### ✅ No issues found!" >> output.txt
-        cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
+        cat output.txt >> $GITHUB_STEP_SUMMARY
 
     - name: Output findings to summary
       shell: bash
@@ -58,7 +58,7 @@ runs:
         # echo "| -- | -- | -- | -- | " >> output.txt
         # tail -n +2 scan.csv | awk '{ if ($1=="HIGH" || $1=="CRITICAL") {printf "|"; printf $1; printf "|"; printf $2; printf "|"; printf $5; printf "|"; printf $9; print "|" }}' FPAT='[^,]*|("([^"]|"")*")' >> output.txt
         echo "</details>" >> output.txt
-        cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
+        cat output.txt >> $GITHUB_STEP_SUMMARY
 
     - name: upload zip
       uses: actions/upload-artifact@v4

--- a/iac-scan/action.yml
+++ b/iac-scan/action.yml
@@ -18,7 +18,7 @@ runs:
       run: ./wizcli auth --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET"
       env:
         WIZ_CLIENT_ID: ${{ inputs.client-id }}
-        WIZ_CLIENT_SECRET: ${{ inputs.client-key }}
+        WIZ_CLIENT_SECRET: ${{ inputs.client-secret }}
 
     - name: Run wiz CLI IaC scan
       run: ./wizcli iac scan --path . --policy "Vermeer IaC Policy"

--- a/iac-scan/action.yml
+++ b/iac-scan/action.yml
@@ -51,7 +51,7 @@ runs:
       if: ${{ steps.cli-scan.outcome != 'success' }}
       run: |
         echo "### ❌ Issues found!" >> output.txt
-        echo "<details><summary>Please update the following packages in the container image:</summary>" >> output.txt
+        echo "<details><summary>Please address the following misconfigurations in your IaC files:</summary>" >> output.txt
         echo "" >> output.txt
         unzip scan.zip
         echo "|severity|vulnerability|file|line number|description|" >> output.txt

--- a/iac-scan/action.yml
+++ b/iac-scan/action.yml
@@ -1,6 +1,14 @@
 name: Wiz IaC Scan
 
 inputs:
+  app-id:
+    description: GitHub App ID used to comment on PR
+    required: false
+    default: ""
+  app-key:
+    description: Private key for above App ID
+    required: false
+    default: "no-key"
   client-id:
     description: Wiz service account client ID
     required: true
@@ -25,14 +33,23 @@ runs:
 
     - name: Run Wiz CLI IaC scan
       run: |
-        echo "# Wiz IaC Scan" >> $GITHUB_STEP_SUMMARY
+        echo "# Wiz IaC Scan" >> output.txt
         ./wizcli iac scan --path . --policy "Vermeer IaC Policy" --output scan.txt,human,true
-        echo "### ✅ No issues found!" >> $GITHUB_STEP_SUMMARY
+        echo "### ✅ No issues found!" >> output.txt
+        cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
 
     - name: Output findings to summary
       if: ${{ failure() }}
       run: |
-        echo "### ❌ Issues found!" >> $GITHUB_STEP_SUMMARY
-        cat scan.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "Please address the above misconfigurations." >> $GITHUB_STEP_SUMMARY
+        echo "### ❌ Issues found!" >> output.txt
+        cat scan.txt | xargs -n1 -d'\n' echo "$*" >> output.txt
+        echo "" >> output.txt
+        echo "Please address the above misconfigurations." >> output.txt
+        cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
+
+    - name: Comment on PR
+      if: ${{ inputs.app-key != 'no-key' && failure() }}
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
+        filePath: ./output.txt

--- a/iac-scan/action.yml
+++ b/iac-scan/action.yml
@@ -54,9 +54,9 @@ runs:
         echo "<details><summary>Please update the following packages in the container image:</summary>" >> output.txt
         echo "" >> output.txt
         unzip scan.zip
-        # echo "|severity|vulnerability|name|description|" >> output.txt
-        # echo "| -- | -- | -- | -- | " >> output.txt
-        # tail -n +2 scan.csv | awk '{ if ($1=="HIGH" || $1=="CRITICAL") {printf "|"; printf $1; printf "|"; printf $2; printf "|"; printf $5; printf "|"; printf $9; print "|" }}' FPAT='[^,]*|("([^"]|"")*")' >> output.txt
+        echo "|severity|vulnerability|file|line number|description|" >> output.txt
+        echo "| -- | -- | -- | -- | -- | " >> output.txt
+        tail -n +2 scan.csv | awk '{ if ($1=="HIGH" || $1=="CRITICAL") {printf "|"; printf $1; printf "|"; printf $2; printf "|"; printf $4; printf "|"; printf $6; printf "|"; printf $10; print "|" }}' FPAT='[^,]*|("([^"]|"")*")' >> output.txt
         echo "</details>" >> output.txt
         cat output.txt >> $GITHUB_STEP_SUMMARY
 

--- a/iac-scan/action.yml
+++ b/iac-scan/action.yml
@@ -18,34 +18,54 @@ inputs:
 
 runs:
   using: "composite"
-  defaults:
-      run:
-        shell: bash
+
   steps:
     - name: Download Wiz CLI
+      shell: bash
       run: curl -o wizcli https://wizcli.app.wiz.io/latest/wizcli && chmod +x wizcli
 
     - name: Authenticate to Wiz
+      shell: bash
       run: ./wizcli auth --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET"
       env:
         WIZ_CLIENT_ID: ${{ inputs.client-id }}
         WIZ_CLIENT_SECRET: ${{ inputs.client-secret }}
 
     - name: Run Wiz CLI IaC scan
+      id: cli-scan
+      continue-on-error: true
+      shell: bash
       run: |
         echo "# Wiz IaC Scan" >> output.txt
-        ./wizcli iac scan --path . --policy "Vermeer IaC Policy" --output scan.txt,human,true
+        ./wizcli iac scan --path . --policy "Vermeer IaC Policy" --policy-hits-only --output scan.zip,csv-zip,true
+
+    - name: Output findings to summary
+      shell: bash
+      if: ${{ steps.cli-scan.outcome == 'success' }}
+      run: |
         echo "### ✅ No issues found!" >> output.txt
         cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
 
     - name: Output findings to summary
-      if: ${{ failure() }}
+      shell: bash
+      if: ${{ steps.cli-scan.outcome != 'success' }}
       run: |
         echo "### ❌ Issues found!" >> output.txt
-        cat scan.txt | xargs -n1 -d'\n' echo "$*" >> output.txt
+        echo "<details><summary>Please update the following packages in the container image:</summary>" >> output.txt
         echo "" >> output.txt
-        echo "Please address the above misconfigurations." >> output.txt
+        unzip scan.zip
+        # echo "|severity|vulnerability|name|description|" >> output.txt
+        # echo "| -- | -- | -- | -- | " >> output.txt
+        # tail -n +2 scan.csv | awk '{ if ($1=="HIGH" || $1=="CRITICAL") {printf "|"; printf $1; printf "|"; printf $2; printf "|"; printf $5; printf "|"; printf $9; print "|" }}' FPAT='[^,]*|("([^"]|"")*")' >> output.txt
+        echo "</details>" >> output.txt
         cat output.txt | xargs -n1 -d'\n' echo "$*" >> $GITHUB_STEP_SUMMARY
+
+    - name: upload zip
+      uses: actions/upload-artifact@v4
+      if:  ${{ steps.cli-scan.outcome != 'success' }}
+      with:
+        name: wiz-artifact
+        path: scan.zip
 
     - name: Comment on PR
       if: ${{ inputs.app-key != 'no-key' && failure() }}


### PR DESCRIPTION
Using the iac-scan action in a standalone workflow:

```yaml
name: 'IaC Scan'
on: [pull_request]

jobs:
  iac-scan:
    name: 'IaC Scan'
    runs-on: ubuntu-latest
    defaults:
      run:
        shell: bash

    steps:
    - name: Check out repository
      uses: actions/checkout@v4

    - name: Scan IaC for misconfigurations
      uses: vermeer-corp/sec-ci-actions/iac-scan@main
      with:
        client-id: ${{ secrets.WIZ_CLIENT_ID }}
        client-secret: ${{ secrets.WIZ_CLIENT_SECRET }}
```

Using the container-scan action in an existing build workflow:

```yaml

...

    - name: Scan image for vulnerabilities
      uses: vermeer-corp/sec-ci-actions/container-scan@main
      with:
        client-id: ${{ secrets.WIZ_CLIENT_ID }}
        client-secret: ${{ secrets.WIZ_CLIENT_SECRET }}
        tag: <your-image-tag>

...
```