### PR TITLE
add secrets policy to IaC scan

### DIFF
--- a/container-scan/action.yml
+++ b/container-scan/action.yml
@@ -82,3 +82,8 @@ runs:
       with:
         GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
         filePath: ./output.txt
+
+    - name: Fail workflow on scan policy failure
+      if: ${{ steps.cli-scan.outcome != 'success' }}
+      shell: bash
+      run: exit 1

--- a/iac-scan/action.yml
+++ b/iac-scan/action.yml
@@ -51,7 +51,7 @@ runs:
         echo "# Wiz IaC Scan" >> output.txt
         ./wizcli iac scan --path "$SCANPATH" --type "$SCANTYPE" --policy "Vermeer IaC Policy,Vermeer Secrets Policy" --policy-hits-only --output scan.zip,csv-zip,true
       env:
-        SCANPATH: ${{ inputs.paths }}
+        SCANPATH: ${{ inputs.paths }}  # use env to avoid command-line injection vulnerability
         SCANTYPE: ${{ inputs.types }}
 
     - name: Output findings to summary

--- a/iac-scan/action.yml
+++ b/iac-scan/action.yml
@@ -41,7 +41,7 @@ runs:
       shell: bash
       run: |
         echo "# Wiz IaC Scan" >> output.txt
-        ./wizcli iac scan --path . --policy "Vermeer IaC Policy" --policy-hits-only --output scan.zip,csv-zip,true
+        ./wizcli iac scan --path . --policy "Vermeer IaC Policy,Vermeer Secrets Policy" --policy-hits-only --output scan.zip,csv-zip,true
 
     - name: Output findings to summary
       shell: bash

--- a/iac-scan/action.yml
+++ b/iac-scan/action.yml
@@ -19,6 +19,14 @@ inputs:
   client-secret:
     description: Wiz service account client secret
     required: true
+  paths:
+    description: File/directory to scan
+    required: false
+    default: "."
+  types:
+    description: Narrow down the scan to specific types (supported values - Ansible, AzureResourceManager, Cloudformation, Dockerfile, GoogleCloudDeploymentManager, Kubernetes, Terraform)
+    required: false
+    default: "Ansible,AzureResourceManager,Cloudformation,Dockerfile,GoogleCloudDeploymentManager,Kubernetes,Terraform"
 
 runs:
   using: "composite"
@@ -41,7 +49,10 @@ runs:
       shell: bash
       run: |
         echo "# Wiz IaC Scan" >> output.txt
-        ./wizcli iac scan --path . --policy "Vermeer IaC Policy,Vermeer Secrets Policy" --policy-hits-only --output scan.zip,csv-zip,true
+        ./wizcli iac scan --path "$SCANPATH" --type "$SCANTYPE" --policy "Vermeer IaC Policy,Vermeer Secrets Policy" --policy-hits-only --output scan.zip,csv-zip,true
+      env:
+        SCANPATH: ${{ inputs.paths }}
+        SCANTYPE: ${{ inputs.types }}
 
     - name: Output findings to summary
       shell: bash

--- a/iac-scan/action.yml
+++ b/iac-scan/action.yml
@@ -78,8 +78,13 @@ runs:
         path: scan.zip
 
     - name: Comment on PR
-      if: ${{ inputs.app-key != 'no-key' && failure() }}
+      if: ${{ inputs.app-key != 'no-key' && steps.cli-scan.outcome != 'success' }}
       uses: thollander/actions-comment-pull-request@v2
       with:
         GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
         filePath: ./output.txt
+
+    - name: Fail workflow on scan policy failure
+      if: ${{ steps.cli-scan.outcome != 'success' }}
+      shell: bash
+      run: exit 1

--- a/iac-scan/action.yml
+++ b/iac-scan/action.yml
@@ -49,10 +49,10 @@ runs:
       shell: bash
       run: |
         echo "# Wiz IaC Scan" >> output.txt
-        ./wizcli iac scan --path "$SCANPATH" --type "$SCANTYPE" --policy "Vermeer IaC Policy,Vermeer Secrets Policy" --policy-hits-only --output scan.zip,csv-zip,true
+        ./wizcli iac scan --path "$SCANPATH" --types "$SCANTYPES" --policy "Vermeer IaC Policy,Vermeer Secrets Policy" --policy-hits-only --output scan.zip,csv-zip,true
       env:
         SCANPATH: ${{ inputs.paths }}  # use env to avoid command-line injection vulnerability
-        SCANTYPE: ${{ inputs.types }}
+        SCANTYPES: ${{ inputs.types }}
 
     - name: Output findings to summary
       shell: bash

--- a/iac-scan/action.yml
+++ b/iac-scan/action.yml
@@ -19,10 +19,6 @@ inputs:
   client-secret:
     description: Wiz service account client secret
     required: true
-  paths:
-    description: File/directory to scan
-    required: false
-    default: "."
   types:
     description: Narrow down the scan to specific types (supported values - Ansible, AzureResourceManager, Cloudformation, Dockerfile, GoogleCloudDeploymentManager, Kubernetes, Terraform)
     required: false
@@ -49,10 +45,9 @@ runs:
       shell: bash
       run: |
         echo "# Wiz IaC Scan" >> output.txt
-        ./wizcli iac scan --path "$SCANPATH" --types "$SCANTYPES" --policy "Vermeer IaC Policy,Vermeer Secrets Policy" --policy-hits-only --output scan.zip,csv-zip,true
+        ./wizcli iac scan --path . --types "$SCANTYPES" --policy "Vermeer IaC Policy,Vermeer Secrets Policy" --policy-hits-only --output scan.zip,csv-zip,true
       env:
-        SCANPATH: ${{ inputs.paths }}  # use env to avoid command-line injection vulnerability
-        SCANTYPES: ${{ inputs.types }}
+        SCANTYPES: ${{ inputs.types }}  # use env to avoid command-line injection vulnerability
 
     - name: Output findings to summary
       shell: bash


### PR DESCRIPTION
Didn't realize IaC scans can use our secrets policy.

In theory, GitGuardian should catch the secrets if it's in IaC files. Maybe it doesn't make sense to add this additional check.

What do you think @tah8940?